### PR TITLE
Allow ORG_URL to be configured outside of script.

### DIFF
--- a/kickstart
+++ b/kickstart
@@ -4,7 +4,7 @@ set -euo pipefail
 
 ROOT_DIR=/opt/halyard
 REPO_DIR="$ROOT_DIR/repo"
-ORG_URL=https://github.com/halyard
+ORG_URL="${ORG_URL:-https://github.com/halyard}"
 
 function darwin() {
     REPO_NAME=halyard


### PR DESCRIPTION
This will allow a fork of halyard/halyard to be used.
```
$ export ORG_URL=https://github.com/double16
# curl -sLo kickstart https://git.io/halyard
$ sudo bash kickstart
```
